### PR TITLE
mudança de cor

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -246,7 +246,7 @@ section a:active{
 }
 
 .green-color{
-    color: #437d43;
+    color: #5139c0;
 }
 
 .whatsapp {


### PR DESCRIPTION
mudei a cor do nome IFNMG na imagem inicial, porque a cor verde não estava contrastando com o resto dos elementos