### PR TITLE
Bug de formatação e remoção da inscrição

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -207,7 +207,7 @@ section a:active{
     color: #ddd;
 }
 
-#location .content{
+.content{
     display: flex;
     justify-content: center;
     align-items: center;

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
                     14:00 às 18:00 da Quinta-Feira (03/10).
                 </p>
                 <br>
-                <a href="https://www.even3.com.br/semanacienciaetecnologiajanauba/" target="_blank" class="button">Increva-se</a>
+                <a class="button">*inscrições encerradas</a>
                 <br><br>
                 <p>
                     Compartilhe:<br>


### PR DESCRIPTION
  O motivo da imagem não estar centralizada mesmo com a classe content, é que o mesmo estava limitada ao ID location, com isso eu removi essa limitação do código main.css. Eu removi o link de inscrição já que o evento já se encerrou.