### PR TITLE
Fix galeria image width

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -303,3 +303,9 @@ section a:active{
      rgb(0, 68, 255));
     color: white;
 }
+
+#galeria .content img{
+    width: 90%;
+    border-radius: 5px;
+    box-shadow: 2px 3px 5px 3px rgba(15, 25, 53, 0.5);
+}

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
                     14:00 às 18:00 da Quinta-Feira (03/10).
                 </p>
                 <br>
-                <a class="button">*inscrições encerradas</a>
+                <a class="button">Inscrições encerradas</a>
                 <br><br>
                 <p>
                     Compartilhe:<br>


### PR DESCRIPTION
A comprimento da imagem da galeria era muito alto para dispositivos móveis, e portanto comprometia a responsividade do site. Nesse caso, limitei o comprimento das imagens na galeria a apenas 90% do elemento pai.